### PR TITLE
Add support for --domain-controller adcli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Defines the Active Directory domain to join
 Type: string
 Default: undef
 
+`ad_domain_controller`
+Connect to a specific domain controller. If not specified then an appropriate domain controller is automatically discovered.
+Type: string
+Required: false
+Default: undef
+
 `ad_join_username`
 Defines the Active Directory username to use during domain join operations.
 Type: string

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,12 @@
 #   Required: true
 #   Default: undef
 #
+# [*ad_domain_controller*]
+#   Connect to a specific domain controller. If not specified then an
+#   appropriate domain controller is automatically discovered.
+#   Required: false
+#   Default: undef
+#
 # [*ad_join_username*]
 #   Username to use during AD join operation.
 #   Required: true
@@ -43,12 +49,14 @@
 #
 class adcli (
   $ad_domain               = $adcli::params::ad_domain,
+  $ad_domain_controller    = $adcli::params::ad_domain_controller,
   $ad_join_username        = $adcli::params::ad_join_username,
   $ad_join_password        = $adcli::params::ad_join_password,
   $ad_join_ou              = $adcli::params::ad_join_ou,
 ) inherits adcli::params {
 
   validate_legacy(String, 'validate_string', $ad_domain)
+  validate_legacy(String, 'validate_string', $ad_domain_controller)
   validate_legacy(String, 'validate_string', $ad_join_username)
   validate_legacy(String, 'validate_string', $ad_join_password)
   validate_legacy(String, 'validate_string', $ad_join_ou)

--- a/manifests/join.pp
+++ b/manifests/join.pp
@@ -5,10 +5,11 @@
 # See README.md for more details
 #
 class adcli::join (
-  $ad_domain        = $adcli::ad_domain,
-  $ad_join_username = $adcli::ad_join_username,
-  $ad_join_password = $adcli::ad_join_password,
-  $ad_join_ou       = $adcli::ad_join_ou
+  $ad_domain            = $adcli::ad_domain,
+  $ad_domain_controller = $adcli::ad_domain_controller,
+  $ad_join_username     = $adcli::ad_join_username,
+  $ad_join_password     = $adcli::ad_join_password,
+  $ad_join_ou           = $adcli::ad_join_ou,
 ) {
   if $ad_domain == undef {
     notify {'For Active Directory join to work you must specify the ad_domain parameter.':}
@@ -24,7 +25,7 @@ class adcli::join (
   }
   else {
     exec {'adcli_join':
-      command   => "/bin/echo -n \'${ad_join_password}\' | /usr/sbin/adcli join --login-user=\'${ad_join_username}\' --domain=\'${ad_domain}\' --domain-ou=\'${ad_join_ou}\' --stdin-password --verbose",
+      command   => "/bin/echo -n \'${ad_join_password}\' | /usr/sbin/adcli join --domain-controller=\'${ad_domain_controller}\' --login-user=\'${ad_join_username}\' --domain=\'${ad_domain}\' --domain-ou=\'${ad_join_ou}\' --stdin-password --verbose",
       logoutput => true,
       creates   => '/etc/krb5.keytab',
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,11 @@ class adcli::params {
   #  Parameters :: adcli
   # ----------------------------------------------------------------------------
 
-  $ad_domain        = undef
-  $ad_join_username = undef
-  $ad_join_password = undef
-  $ad_join_ou       = undef
+  $ad_domain            = undef
+  $ad_domain_controller = undef
+  $ad_join_username     = undef
+  $ad_join_password     = undef
+  $ad_join_ou           = undef
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease < '6' {
     fail("Unsupported platform: puppet-adcli does not currently support RedHat ${::operatingsystemmajrelease}")


### PR DESCRIPTION
This adds a parameter to specify the domain controller to join, instead of relying on discovery to join the domain.

```puppet
# [*ad_domain_controller*]
#   Connect to a specific domain controller. If not specified then an
#   appropriate domain controller is automatically discovered.
#   Required: false
#   Default: undef
```