### PR TITLE
Updated /usr/sbin/adcli testjoin condition

### DIFF
--- a/manifests/join.pp
+++ b/manifests/join.pp
@@ -66,7 +66,7 @@ ${ad_join_computer_name_command} --login-user=\'${ad_join_username}\' --domain=\
 --stdin-password --verbose ${ad_join_os_command} ${ad_join_os_version_command} ${ad_join_os_service_pack_command} \
 ${ad_join_service_names_command}",
       logoutput => true,
-      unless    => '/usr/sbin/adcli testjoin',
+      unless    => "/usr/sbin/adcli testjoin -D ${ad_domain}",
     }
   }
 }


### PR DESCRIPTION
'adcli testjoin' is great when your hostname domain matches joined domain.
For cases when you joined a different domain it's better to include it's full domain name in a validation.