### PR TITLE
Bump up puppetlabs-stdlib and puppet requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.0 < 6.0.0"
+      "version_requirement": ">= 2.3.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -32,7 +32,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
I've verified that this still works with puppetlabs-stdlib v6.6.0 and puppet 5.5.22. Let's bump up the requirements so that they don't show errors on the module list.